### PR TITLE
fixing an error located while seeding on a fresh new install

### DIFF
--- a/app/Question.php
+++ b/app/Question.php
@@ -32,6 +32,6 @@ class Question extends Model
     }
 
     public function setAnswerAttribute( $value ) {
-    	$this->attributes['answer'] = json_encode( $value );
+    	$this->attributes['answers'] = json_encode( $value );
     }
 }


### PR DESCRIPTION
```
Seeding: CourseSeed

   Illuminate\Database\QueryException  : SQLSTATE[42S22]: Column not found: 1054 Unknown column 'answer' in 'field list' (SQL: insert into `questions` (`created_by`, `question`, `options`, `answer`, `hint`, `explanation`, `exam_id`, `updated_at`, `created_at`) values (2, Iusto quia provident quia modi voluptatem quam fugit., ["true","false","both","non"], "true", Answer alweas true, you are giving answer form faker generate question, 1, 2020-02-03 14:56:17, 2020-02-03 14:56:17))
```

missing a 's' after answer and broke the seeding process in a fresh install